### PR TITLE
bugfix: adjust client ciphers to working set

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -46,15 +46,15 @@ class ssh_hardening::client (
   }
 
   if $weak_hmac == true {
-    $macs = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-ripemd160,hmac-sha1'
+    $macs = 'hmac-sha2-256,hmac-sha2-512,hmac-ripemd160,hmac-sha1'
   } else {
-    $macs = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-ripemd160'
+    $macs = 'hmac-sha2-256,hmac-sha2-512,hmac-ripemd160'
   }
 
   if $weak_kex == true {
-    $kex = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
+    $kex = 'ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1'
   } else {
-    $kex = 'diffie-hellman-group-exchange-sha256'
+    $kex = 'ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256'
   }
 
   class { 'ssh::client':


### PR DESCRIPTION
client ciphers for some reason had the old set configured; adjust them to the new set

Signed-off-by: Dominik Richter dominik.richter@gmail.com
