### PR TITLE
per suite tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,10 +5,6 @@ driver:
 
 provisioner:
   name: puppet_apply
-  manifests_path: manifests
-  modules_path: modules
-  hiera_data_path: hieradata
-  manifest: site.pp
   test_repo_uri: "https://github.com/TelekomLabs/tests-ssh-hardening.git"
 
 platforms:
@@ -43,5 +39,5 @@ platforms:
     box_url: https://dl.dropboxusercontent.com/s/cd583cuf0mbcix7/debian-wheezy-64-chef.box
 
 suites:
-  - name: default
-
+- name: default
+  manifest: site.pp

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
-  gem 'kitchen-puppet', :github => "ehaselwanter/kitchen-puppet", :branch => "repo_is_module"
+  gem 'kitchen-puppet', '~> 0.0.11'
   gem 'librarian-puppet'
   gem 'puppet'
   gem 'kitchen-sharedtests', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git://github.com/ehaselwanter/kitchen-puppet.git
-  revision: ba62c21d8efa623c3cff8cbe5120ea1720488cae
-  branch: repo_is_module
-  specs:
-    kitchen-puppet (0.0.9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -32,6 +25,7 @@ GEM
     highline (1.6.21)
     json (1.8.1)
     json_pure (1.8.1)
+    kitchen-puppet (0.0.11)
     kitchen-sharedtests (0.2.0)
       git
     kitchen-vagrant (0.15.0)
@@ -101,7 +95,7 @@ PLATFORMS
 
 DEPENDENCIES
   guard-rake
-  kitchen-puppet!
+  kitchen-puppet (~> 0.0.11)
   kitchen-sharedtests (~> 0.2.0)
   kitchen-vagrant
   librarian-puppet

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,1 +1,0 @@
-class { 'ssh_hardening': }


### PR DESCRIPTION
- the test manifests live now in the integration test suite (were they belong)
- update to use the upstream kitchen-puppet gem (which allows for per suite
  puppet configuration 
- update .kitchen.yml to reflect this changes
