### PR TITLE
Code simplification and optional PAM support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,8 @@ class ssh_hardening(
   $client_alive_interval = 600,
   $client_alive_count    = 3,
   $allow_root_with_key   = false,
-  $ipv6_enabled          = false
+  $ipv6_enabled          = false,
+  $use_pam               = false,
 ) {
   class { 'ssh_hardening::server':
     cbc_required          => $cbc_required,
@@ -72,6 +73,7 @@ class ssh_hardening(
     client_alive_count    => $client_alive_count,
     allow_root_with_key   => $allow_root_with_key,
     ipv6_enabled          => $ipv6_enabled,
+    use_pam               => $use_pam,
   }
   class { 'ssh_hardening::client':
     ipv6_enabled => $ipv6_enabled,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,7 +59,8 @@ class ssh_hardening::server (
   $client_alive_interval = 600,
   $client_alive_count    = 3,
   $allow_root_with_key   = false,
-  $ipv6_enabled          = false
+  $ipv6_enabled          = false,
+  $use_pam               = false,
 ) {
 
   $addressfamily = $ipv6_enabled ? {
@@ -84,6 +85,11 @@ class ssh_hardening::server (
 
   $permit_root_login = $allow_root_with_key ? {
     true  => 'without-password',
+    false => 'no',
+  }
+
+  $use_pam_option = $use_pam ? {
+    true  => 'yes',
     false => 'no',
   }
 
@@ -181,7 +187,7 @@ class ssh_hardening::server (
 
       # Disable password-based authentication, it can allow for
       # potentially easier brute-force attacks.
-      'UsePAM'                          => 'no',
+      'UsePAM'                          => $use_pam_option,
       'PasswordAuthentication'          => 'no',
       'PermitEmptyPasswords'            => 'no',
       'ChallengeResponseAuthentication' => 'no',


### PR DESCRIPTION
I've simplified some if-else constructs by using Puppet's selector. This should make it easier to browse the code and understand then intention of the author.

I've also added an option to enable PAM. On Ubuntu 12.04 LTS there is some initialization done which needs either UseLogin or UsePAM enabled. UseLogin is disabled by default on Ubuntu, but UsePAM is enabled. Without them enabled, you get warnings about missing locales if the client uses a different locale than the server. This results in subsequent error messages of tools like apt, bash's commandline completion or command-not-found.
