### PR TITLE
feature: add configurable agent and tcp forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This module provides secure ssh-client and ssh-server configurations.
 * `ports = [ 22 ]` - ports to which ssh-server should listen to and ssh-client should connect to
 * `listen_to = [ "0.0.0.0" ]` - one or more ip addresses, to which ssh-server should listen to. Default is empty, but should be configured for security reasons!
 * `remote_hosts` - one or more hosts, to which ssh-client can connect to. Default is empty, but should be configured for security reasons!
+* `allow_tcp_forwarding = false` - set to true to allow TCP forwarding
+* `allow_agent_forwarding = false` - set to true to allow Agent forwarding
 
 ## Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,12 @@
 # [*ipv6_enabled*]
 #   Set to true if you need IPv6 support in SSH.
 #
+# [*allow_tcp_forwarding*]
+#   Set to true to allow TCP forwarding
+#
+# [*allow_agent_forwarding*]
+#   Set to true to allow Agent forwarding
+#
 # === Copyright
 #
 # Copyright 2014, Deutsche Telekom AG
@@ -61,19 +67,23 @@ class ssh_hardening(
   $allow_root_with_key   = false,
   $ipv6_enabled          = false,
   $use_pam               = false,
+  $allow_tcp_forwarding   = false,
+  $allow_agent_forwarding = false,
 ) {
   class { 'ssh_hardening::server':
-    cbc_required          => $cbc_required,
-    weak_hmac             => $weak_hmac,
-    weak_kex              => $weak_kex,
-    ports                 => $ports,
-    listen_to             => $listen_to,
-    host_key_files        => $host_key_files,
-    client_alive_interval => $client_alive_interval,
-    client_alive_count    => $client_alive_count,
-    allow_root_with_key   => $allow_root_with_key,
-    ipv6_enabled          => $ipv6_enabled,
-    use_pam               => $use_pam,
+    cbc_required           => $cbc_required,
+    weak_hmac              => $weak_hmac,
+    weak_kex               => $weak_kex,
+    ports                  => $ports,
+    listen_to              => $listen_to,
+    host_key_files         => $host_key_files,
+    client_alive_interval  => $client_alive_interval,
+    client_alive_count     => $client_alive_count,
+    allow_root_with_key    => $allow_root_with_key,
+    ipv6_enabled           => $ipv6_enabled,
+    use_pam                => $use_pam,
+    allow_tcp_forwarding   => false,
+    allow_agent_forwarding => false,
   }
   class { 'ssh_hardening::client':
     ipv6_enabled => $ipv6_enabled,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -46,21 +46,23 @@
 # Copyright 2014, Deutsche Telekom AG
 #
 class ssh_hardening::server (
-  $cbc_required          = false,
-  $weak_hmac             = false,
-  $weak_kex              = false,
-  $ports                 = [ 22 ],
-  $listen_to             = [ '0.0.0.0' ],
-  $host_key_files        = [
+  $cbc_required           = false,
+  $weak_hmac              = false,
+  $weak_kex               = false,
+  $ports                  = [ 22 ],
+  $listen_to              = [ '0.0.0.0' ],
+  $host_key_files         = [
     '/etc/ssh/ssh_host_rsa_key',
     '/etc/ssh/ssh_host_dsa_key',
     '/etc/ssh/ssh_host_ecdsa_key'
     ],
-  $client_alive_interval = 600,
-  $client_alive_count    = 3,
-  $allow_root_with_key   = false,
-  $ipv6_enabled          = false,
-  $use_pam               = false,
+  $client_alive_interval  = 600,
+  $client_alive_count     = 3,
+  $allow_root_with_key    = false,
+  $ipv6_enabled           = false,
+  $use_pam                = false,
+  $allow_tcp_forwarding   = false,
+  $allow_agent_forwarding = false,
 ) {
 
   $addressfamily = $ipv6_enabled ? {
@@ -91,6 +93,16 @@ class ssh_hardening::server (
   $use_pam_option = $use_pam ? {
     true  => 'yes',
     false => 'no',
+  }
+
+  $tcp_forwarding = $allow_tcp_forwarding ? {
+    true  => 'yes',
+    false => 'no'
+  }
+
+  $agent_forwarding = $allow_agent_forwarding ? {
+    true  => 'yes',
+    false => 'no'
   }
 
   class { 'ssh::server':
@@ -229,11 +241,11 @@ class ssh_hardening::server (
 
       # Disable forwarding tcp connections.
       # no real advantage without denied shell access
-      'AllowTcpForwarding'              => 'yes',
+      'AllowTcpForwarding'              => $tcp_forwarding,
 
       # Disable agent formwarding, since local agent could be accessed through
       # forwarded connection. No real advantage without denied shell access
-      'AllowAgentForwarding'            => 'yes',
+      'AllowAgentForwarding'            => $agent_forwarding,
 
       # Do not allow remote port forwardings to bind to non-loopback addresses.
       'GatewayPorts'                    => 'no',


### PR DESCRIPTION
This solves 2 errors in the current test suite for the appropriate attributes, since the default for these 2 types of forwarding is changed from true -> false. (which is what the tests want)

Signed-off-by: Dominik Richter dominik.richter@gmail.com
