### PR TITLE
Debian

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,12 +36,14 @@ platforms:
 - name: debian-6
   driver_config:
     box: debian-6
-    box_url: http://public.sphax3d.org/vagrant/squeeze64.box
+    # source: https://github.com/ffuenf/vagrant-boxes
+    box_url: https://googledrive.com/host/0B83ZToJ3fGtDeE9KWm1sWndZdGs/debian-6.0.9-amd64_virtualbox.box
 
 - name: debian-7
   driver_config:
     box: debian-7
-    box_url: https://dl.dropboxusercontent.com/s/cd583cuf0mbcix7/debian-wheezy-64-chef.box
+    # source: https://github.com/ffuenf/vagrant-boxes
+    box_url: https://googledrive.com/host/0B83ZToJ3fGtDVC1DeVVzc3lkc0U/debian-7.5.0-amd64_virtualbox.box
 
 suites:
 - name: default


### PR DESCRIPTION
Simplify debian box naming and fix the choice of debian boxes (7 wasn't working anymore).
