### PR TITLE
reduce OS release distinction in crypto to majors

### DIFF
--- a/lib/puppet/parser/functions/get_ssh_ciphers.rb
+++ b/lib/puppet/parser/functions/get_ssh_ciphers.rb
@@ -1,6 +1,7 @@
 Puppet::Parser::Functions::newfunction(:get_ssh_ciphers, :type => :rvalue) do |args|
   os = args[0].downcase
   osrelease = args[1]
+  osmajor = osrelease.sub(/\..*/,'')
   weak_ciphers = args[2] ? 'weak' : 'default'
 
   ciphers_53 = {}
@@ -20,18 +21,17 @@ Puppet::Parser::Functions::newfunction(:get_ssh_ciphers, :type => :rvalue) do |a
   m.default = default_vmap
 
   m['ubuntu'] = {}
-  m['ubuntu']['12.04'] = ciphers_53
-  m['ubuntu']['14.04'] = ciphers_66
+  m['ubuntu']['12'] = ciphers_53
+  m['ubuntu']['14'] = ciphers_66
   m['ubuntu'].default = ciphers_53
 
   m['redhat'] = {}
-  m['redhat']['6.4'] = ciphers_53
-  m['redhat']['6.5'] = ciphers_53
+  m['redhat']['6'] = ciphers_53
   m['redhat'].default = ciphers_53
 
   m['centos'] = m['redhat']
   m['oraclelinux'] = m['redhat']
 
-  m[os][osrelease][weak_ciphers]
+  m[os][osmajor][weak_ciphers]
 end
 

--- a/lib/puppet/parser/functions/get_ssh_kex.rb
+++ b/lib/puppet/parser/functions/get_ssh_kex.rb
@@ -1,6 +1,7 @@
 Puppet::Parser::Functions::newfunction(:get_ssh_kex, :type => :rvalue) do |args|
   os = args[0].downcase
   osrelease = args[1]
+  osmajor = osrelease.sub(/\..*/,'')
   weak_kex = args[2] ? 'weak' : 'default'
 
   kex_59 = {}
@@ -20,17 +21,16 @@ Puppet::Parser::Functions::newfunction(:get_ssh_kex, :type => :rvalue) do |args|
   m.default = default_vmap
 
   m['ubuntu'] = {}
-  m['ubuntu']['12.04'] = kex_59
-  m['ubuntu']['14.04'] = kex_66
+  m['ubuntu']['12'] = kex_59
+  m['ubuntu']['14'] = kex_66
   m['ubuntu'].default = kex_59
 
   m['redhat'] = {}
-  m['redhat']['6.4'] = ''
-  m['redhat']['6.5'] = ''
+  m['redhat']['6'] = ''
   m['redhat'].default = kex_59
 
   m['centos'] = m['redhat']
   m['oraclelinux'] = m['redhat']
 
-  m[os][osrelease][weak_kex]
+  m[os][osmajor][weak_kex]
 end

--- a/lib/puppet/parser/functions/get_ssh_macs.rb
+++ b/lib/puppet/parser/functions/get_ssh_macs.rb
@@ -1,6 +1,7 @@
 Puppet::Parser::Functions::newfunction(:get_ssh_macs, :type => :rvalue) do |args|
   os = args[0].downcase
   osrelease = args[1]
+  osmajor = osrelease.sub(/\..*/,'')
   weak_macs = args[2] ? 'weak' : 'default'
 
   macs_53 = {}
@@ -23,18 +24,17 @@ Puppet::Parser::Functions::newfunction(:get_ssh_macs, :type => :rvalue) do |args
   m.default = default_vmap
 
   m['ubuntu'] = {}
-  m['ubuntu']['12.04'] = macs_59
-  m['ubuntu']['14.04'] = macs_66
+  m['ubuntu']['12'] = macs_59
+  m['ubuntu']['14'] = macs_66
   m['ubuntu'].default = macs_59
 
   m['redhat'] = {}
-  m['redhat']['6.4'] = macs_53
-  m['redhat']['6.5'] = macs_53
+  m['redhat']['6'] = macs_53
   m['redhat'].default = macs_53
 
   m['centos'] = m['redhat']
   m['oraclelinux'] = m['redhat']
 
-  m[os][osrelease][weak_macs]
+  m[os][osmajor][weak_macs]
 end
 


### PR DESCRIPTION
only do major releases as the subversions inside a major stay the same. the only exception here is ubuntu, which changes from 12.04 to 12.10 and 14.04 to 14.10. The supported set still works perfectly between these.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
