### PR TITLE
bugfix: don't set 'undef' values in ssh client config

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,3 +8,4 @@ description 'Installs and configures OpenSSH with hardening'
 project_page 'https://github.com/TelekomLabs/puppet-ssh-hardening'
 
 dependency 'saz/ssh', '2.3.6'
+dependency 'puppetlabs/stdlib', '>= 4.2.0'

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -43,95 +43,97 @@ class ssh_hardening::client (
   $macs = get_ssh_macs($::operatingsystem, $::operatingsystemrelease, $weak_hmac)
   $kex = get_ssh_kex($::operatingsystem, $::operatingsystemrelease, $weak_kex)
 
+  $ssh_options = {
+    # Set the addressfamily according to IPv4 / IPv6 settings
+    'AddressFamily'             => $addressfamily,
+
+    # The port at the destination should be defined
+    'Port'                      => $ports,
+
+    # Set the protocol family to 2 for security reasons.
+    # Disables legacy support.
+    'Protocol'                  => 2,
+
+    # Make sure passphrase querying is enabled
+    'BatchMode'                 => 'no',
+
+    # Prevent IP spoofing by checking to host IP against the
+    # `known_hosts` file.
+    'CheckHostIP'               => 'yes',
+
+    # Always ask before adding keys to the `known_hosts` file.
+    # Do not set to `yes`.
+    'StrictHostKeyChecking'     => 'ask',
+
+    # **Ciphers** -- If your clients don't support CTR (eg older versions),
+    #   cbc will be added
+    # CBC: is true if you want to connect with OpenSSL-base libraries
+    # eg Ruby's older Net::SSH::Transport::CipherFactory requires CBC-versions
+    # of the given openssh ciphers to work
+    #
+    'Ciphers'                   => $ciphers,
+
+    # **Hash algorithms** -- Make sure not to use SHA1
+    # for hashing, unless it is really necessary.
+    # Weak HMAC is sometimes required if older package
+    # versions are used
+    # eg Ruby's Net::SSH at around 2.2.* doesn't support
+    # sha2 for hmac, so this will have to be set true in this case.
+    #
+    'MACs'                      => $macs,
+
+    # Alternative setting, if OpenSSH version is below v5.9
+    #MACs hmac-ripemd160
+
+    # **Key Exchange Algorithms** -- Make sure not to use SHA1 for kex,
+    # unless it is really necessary
+    # Weak kex is sometimes required if older package versions are used
+    # eg ruby's Net::SSH at around 2.2.* doesn't support sha2 for kex,
+    # so this will have to be set true in this case.
+    #
+    'KexAlgorithms'             => $kex,
+
+    # Disable agent formwarding, since local agent could be accessed
+    # through forwarded connection.
+    'ForwardAgent'              => 'no',
+
+    # Disable X11 forwarding, since local X11 display could be accessed
+    # through forwarded connection.
+    'ForwardX11'                => 'no',
+
+    # Never use host-based authentication. It can be exploited.
+    'HostbasedAuthentication'   => 'no',
+    'RhostsRSAAuthentication'   => 'no',
+
+    # Enable RSA authentication via identity files.
+    'RSAAuthentication'         => 'yes',
+
+    # Disable password-based authentication, it can allow for potentially
+    # easier brute-force attacks.
+    'PasswordAuthentication'    => 'no',
+
+    # Only use GSSAPIAuthentication if implemented on the network.
+    'GSSAPIAuthentication'      => 'no',
+    'GSSAPIDelegateCredentials' => 'no',
+
+    # Disable tunneling
+    'Tunnel'                    => 'no',
+
+    # Disable local command execution.
+    'PermitLocalCommand'        => 'no',
+
+    # Misc. configuration
+    # ===================
+
+    # Enable compression. More pressure on the CPU, less on the network.
+    'Compression'               => 'yes',
+
+    #EscapeChar ~
+    #VisualHostKey yes
+  }
+
   class { 'ssh::client':
     storeconfigs_enabled => false,
-    options              => {
-      # Set the addressfamily according to IPv4 / IPv6 settings
-      'AddressFamily'             => $addressfamily,
-
-      # The port at the destination should be defined
-      'Port'                      => $ports,
-
-      # Set the protocol family to 2 for security reasons.
-      # Disables legacy support.
-      'Protocol'                  => 2,
-
-      # Make sure passphrase querying is enabled
-      'BatchMode'                 => 'no',
-
-      # Prevent IP spoofing by checking to host IP against the
-      # `known_hosts` file.
-      'CheckHostIP'               => 'yes',
-
-      # Always ask before adding keys to the `known_hosts` file.
-      # Do not set to `yes`.
-      'StrictHostKeyChecking'     => 'ask',
-
-      # **Ciphers** -- If your clients don't support CTR (eg older versions),
-      #   cbc will be added
-      # CBC: is true if you want to connect with OpenSSL-base libraries
-      # eg Ruby's older Net::SSH::Transport::CipherFactory requires CBC-versions
-      # of the given openssh ciphers to work
-      #
-      'Ciphers'                   => $ciphers,
-
-      # **Hash algorithms** -- Make sure not to use SHA1
-      # for hashing, unless it is really necessary.
-      # Weak HMAC is sometimes required if older package
-      # versions are used
-      # eg Ruby's Net::SSH at around 2.2.* doesn't support
-      # sha2 for hmac, so this will have to be set true in this case.
-      #
-      'MACs'                      => $macs,
-
-      # Alternative setting, if OpenSSH version is below v5.9
-      #MACs hmac-ripemd160
-
-      # **Key Exchange Algorithms** -- Make sure not to use SHA1 for kex,
-      # unless it is really necessary
-      # Weak kex is sometimes required if older package versions are used
-      # eg ruby's Net::SSH at around 2.2.* doesn't support sha2 for kex,
-      # so this will have to be set true in this case.
-      #
-      'KexAlgorithms'             => $kex,
-
-      # Disable agent formwarding, since local agent could be accessed
-      # through forwarded connection.
-      'ForwardAgent'              => 'no',
-
-      # Disable X11 forwarding, since local X11 display could be accessed
-      # through forwarded connection.
-      'ForwardX11'                => 'no',
-
-      # Never use host-based authentication. It can be exploited.
-      'HostbasedAuthentication'   => 'no',
-      'RhostsRSAAuthentication'   => 'no',
-
-      # Enable RSA authentication via identity files.
-      'RSAAuthentication'         => 'yes',
-
-      # Disable password-based authentication, it can allow for potentially
-      # easier brute-force attacks.
-      'PasswordAuthentication'    => 'no',
-
-      # Only use GSSAPIAuthentication if implemented on the network.
-      'GSSAPIAuthentication'      => 'no',
-      'GSSAPIDelegateCredentials' => 'no',
-
-      # Disable tunneling
-      'Tunnel'                    => 'no',
-
-      # Disable local command execution.
-      'PermitLocalCommand'        => 'no',
-
-      # Misc. configuration
-      # ===================
-
-      # Enable compression. More pressure on the CPU, less on the network.
-      'Compression'               => 'yes',
-
-      #EscapeChar ~
-      #VisualHostKey yes
-    },
+    options              => delete_undef_values($ssh_options),
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,9 @@
     {
       "name": "saz/ssh",
       "version_requirement": "2.3.6"
+    },{
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.2.0"
     }
   ],
   "types": [


### PR DESCRIPTION
This is a workaround until saz/ssh is updated to include this fix upstream. Potentially it may stay in longer, depending on what is the lesser evil: requiring puppetlabs stdlib to be at least v4.2 or requiring saz/ssh to be a minimum of the next version.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
