### PR TITLE
feature: add back puppet 3.4.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: ruby
 bundler_args: --without development integration openstack
 env:
   - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.4.3"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
 matrix:


### PR DESCRIPTION
As it's used per default in trusty, we have to add support for it i.e. tests.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
