### PR TITLE
Pass allow_{tcp,agent}_forwarding to classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,8 +93,8 @@ class ssh_hardening(
     allow_root_with_key    => $allow_root_with_key,
     ipv6_enabled           => $ipv6_enabled,
     use_pam                => $use_pam,
-    allow_tcp_forwarding   => false,
-    allow_agent_forwarding => false,
+    allow_tcp_forwarding   => $allow_tcp_forwarding,
+    allow_agent_forwarding => $allow_agent_forwarding,
     options                => $server_options,
   }
   class { 'ssh_hardening::client':


### PR DESCRIPTION
Right now the variables are hard coded in the class declarations; looks like the intention is for these to be passed to the class declarations.
