### PR TITLE
Do not set default ListenAddress to 0.0.0.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class ssh_hardening(
   $weak_hmac             = false,
   $weak_kex              = false,
   $ports                 = [ 22 ],
-  $listen_to             = [ '0.0.0.0' ],
+  $listen_to             = [],
   $host_key_files        = [
     '/etc/ssh/ssh_host_rsa_key',
     '/etc/ssh/ssh_host_dsa_key',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -56,7 +56,7 @@ class ssh_hardening::server (
   $weak_hmac              = false,
   $weak_kex               = false,
   $ports                  = [ 22 ],
-  $listen_to              = [ '0.0.0.0' ],
+  $listen_to              = [],
   $host_key_files         = [],
   $client_alive_interval  = 600,
   $client_alive_count     = 3,


### PR DESCRIPTION
It is the default on IPv4-only hosts and does not listen on IPv6, even when
$ipv6_enabled is set to true. Set it to an empty array instead which removes
it from the generated configuration