### PR TITLE
Allow MaxAuthRetries to be configurable for SSH server config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,7 @@ class ssh_hardening(
   $use_pam               = false,
   $allow_tcp_forwarding   = false,
   $allow_agent_forwarding = false,
+  $max_auth_retries       = 2,
   $server_options         = {},
   $client_options         = {},
 ) {
@@ -95,6 +96,7 @@ class ssh_hardening(
     use_pam                => $use_pam,
     allow_tcp_forwarding   => $allow_tcp_forwarding,
     allow_agent_forwarding => $allow_agent_forwarding,
+    max_auth_retries       => $max_auth_retries,
     options                => $server_options,
   }
   class { 'ssh_hardening::client':

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -65,6 +65,7 @@ class ssh_hardening::server (
   $use_pam                = false,
   $allow_tcp_forwarding   = false,
   $allow_agent_forwarding = false,
+  $max_auth_retries       = 2,
   $options                = {},
 ) {
 
@@ -173,7 +174,7 @@ class ssh_hardening::server (
       'UsePrivilegeSeparation'          => $priv_sep,
       'PermitUserEnvironment'           => 'no',
       'LoginGraceTime'                  => '30s',
-      'MaxAuthTries'                    => 2,
+      'MaxAuthTries'                    => $max_auth_retries,
       'MaxSessions'                     => 10,
       'MaxStartups'                     => '10:30:100',
 


### PR DESCRIPTION
We need to configure the maxAuthRetries default value.