### PR TITLE
Use ssh version instead of os details

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,5 @@ fixtures:
   repositories:
     ssh: 
       repo: https://github.com/saz/puppet-ssh.git
-      ref: v2.3.6
+      ref: v2.5.0
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/Modulefile
+++ b/Modulefile
@@ -7,5 +7,5 @@ summary 'Installs and configures OpenSSH with hardening'
 description 'Installs and configures OpenSSH with hardening'
 project_page 'https://github.com/TelekomLabs/puppet-ssh-hardening'
 
-dependency 'saz/ssh', '>= 2.3.6'
+dependency 'saz/ssh', '>= 2.5.0'
 dependency 'puppetlabs/stdlib', '>= 4.2.0'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Puppet module provides secure ssh-client and ssh-server configurations.
 ## Requirements
 
 * Puppet
-* Puppet modules: `saz/ssh` (>= 2.3.6), `puppetlabs/stdlib` (>= 4.2.0)
+* Puppet modules: `saz/ssh` (>= 2.5.0), `puppetlabs/stdlib` (>= 4.2.0)
 
 
 ## Parameters

--- a/lib/puppet/parser/functions/get_ssh_ciphers.rb
+++ b/lib/puppet/parser/functions/get_ssh_ciphers.rb
@@ -16,44 +16,18 @@
 #
 
 Puppet::Parser::Functions.newfunction(:get_ssh_ciphers, :type => :rvalue) do |args|
-  os = args[0].downcase
-  osrelease = args[1]
-  osmajor = osrelease.sub(/\..*/, '')
-  weak_ciphers = args[2] ? 'weak' : 'default'
+  ssh_vers = args[0]
+  use_weak = args[1] ? 'weak' : 'default'
 
-  ciphers_53 = {}
-  ciphers_53.default = 'aes256-ctr,aes192-ctr,aes128-ctr'
-  ciphers_53['weak'] = ciphers_53['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
+  # min vers. 5.3
+  ciphers = {}
+  ciphers.default = 'aes256-ctr,aes192-ctr,aes128-ctr'
+  ciphers['weak'] = ciphers['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
 
-  ciphers_66 = {}
-  ciphers_66.default = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
-  ciphers_66['weak'] = ciphers_66['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
+  if Puppet::Util::Package.versioncmp(ssh_vers, '6.6') >= 0
+    ciphers.default = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+    ciphers['weak'] = ciphers['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
+  end
 
-  # creat the default version map (if os + version are default)
-  default_vmap = {}
-  default_vmap.default = ciphers_53
-
-  # create the main map
-  m = {}
-  m.default = default_vmap
-
-  m['ubuntu'] = {}
-  m['ubuntu']['12'] = ciphers_53
-  m['ubuntu']['14'] = ciphers_66
-  m['ubuntu'].default = ciphers_53
-
-  m['debian'] = {}
-  m['debian']['6'] = ciphers_53
-  m['debian']['7'] = ciphers_53
-  m['debian']['8'] = ciphers_66
-  m['debian'].default = ciphers_53
-
-  m['redhat'] = {}
-  m['redhat']['6'] = ciphers_53
-  m['redhat'].default = ciphers_53
-
-  m['centos'] = m['redhat']
-  m['oraclelinux'] = m['redhat']
-
-  m[os][osmajor][weak_ciphers]
+  ciphers[use_weak]
 end

--- a/lib/puppet/parser/functions/get_ssh_kex.rb
+++ b/lib/puppet/parser/functions/get_ssh_kex.rb
@@ -16,44 +16,18 @@
 #
 
 Puppet::Parser::Functions.newfunction(:get_ssh_kex, :type => :rvalue) do |args|
-  os = args[0].downcase
-  osrelease = args[1]
-  osmajor = osrelease.sub(/\..*/, '')
-  weak_kex = args[2] ? 'weak' : 'default'
+  ssh_vers = args[0]
+  use_weak = args[1] ? 'weak' : 'default'
 
-  kex_59 = {}
-  kex_59.default = 'diffie-hellman-group-exchange-sha256'
-  kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
+  # min vers. 5.9
+  kex = {}
+  kex.default = 'diffie-hellman-group-exchange-sha256'
+  kex['weak'] = kex['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
-  kex_66 = {}
-  kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
-  kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
+  if Puppet::Util::Package.versioncmp(ssh_vers, '6.6') >= 0
+    kex.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
+    kex['weak'] = kex['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
+  end
 
-  # creat the default version map (if os + version are default)
-  default_vmap = {}
-  default_vmap.default = kex_59
-
-  # create the main map
-  m = {}
-  m.default = default_vmap
-
-  m['ubuntu'] = {}
-  m['ubuntu']['12'] = kex_59
-  m['ubuntu']['14'] = kex_66
-  m['ubuntu'].default = kex_59
-
-  m['debian'] = {}
-  m['debian']['6'] = ''
-  m['debian']['7'] = kex_59
-  m['debian']['8'] = kex_66
-  m['debian'].default = kex_59
-
-  m['redhat'] = {}
-  m['redhat']['6'] = ''
-  m['redhat'].default = kex_59
-
-  m['centos'] = m['redhat']
-  m['oraclelinux'] = m['redhat']
-
-  m[os][osmajor][weak_kex]
+  kex[use_weak]
 end

--- a/lib/puppet/parser/functions/get_ssh_macs.rb
+++ b/lib/puppet/parser/functions/get_ssh_macs.rb
@@ -16,47 +16,22 @@
 #
 
 Puppet::Parser::Functions.newfunction(:get_ssh_macs, :type => :rvalue) do |args|
-  os = args[0].downcase
-  osrelease = args[1]
-  osmajor = osrelease.sub(/\..*/, '')
-  weak_macs = args[2] ? 'weak' : 'default'
+  ssh_vers = args[0]
+  use_weak = args[1] ? 'weak' : 'default'
 
-  macs_53 = {}
-  macs_53.default = 'hmac-ripemd160,hmac-sha1'
+  # min vers. 5.3
+  macs = {}
+  macs.default = 'hmac-ripemd160,hmac-sha1'
 
-  macs_59 = {}
-  macs_59.default = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
-  macs_59['weak'] = macs_59['default'] + ',hmac-sha1'
+  if Puppet::Util::Package.versioncmp(ssh_vers, '5.9') >= 0
+    macs.default = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
+    macs['weak'] = macs['default'] + ',hmac-sha1'
+  end
 
-  macs_66 = {}
-  macs_66.default = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
-  macs_66['weak'] = macs_66['default'] + ',hmac-sha1'
+  if Puppet::Util::Package.versioncmp(ssh_vers, '6.6') >= 0
+    macs.default = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
+    macs['weak'] = macs['default'] + ',hmac-sha1'
+  end
 
-  # creat the default version map (if os + version are default)
-  default_vmap = {}
-  default_vmap.default = macs_59
-
-  # create the main map
-  m = {}
-  m.default = default_vmap
-
-  m['ubuntu'] = {}
-  m['ubuntu']['12'] = macs_59
-  m['ubuntu']['14'] = macs_66
-  m['ubuntu'].default = macs_59
-
-  m['debian'] = {}
-  m['debian']['6'] = macs_53
-  m['debian']['7'] = macs_59
-  m['debian']['8'] = macs_66
-  m['debian'].default = macs_59
-
-  m['redhat'] = {}
-  m['redhat']['6'] = macs_53
-  m['redhat'].default = macs_53
-
-  m['centos'] = m['redhat']
-  m['oraclelinux'] = m['redhat']
-
-  m[os][osmajor][weak_macs]
+  macs[use_weak]
 end

--- a/lib/puppet/parser/functions/use_privilege_separation.rb
+++ b/lib/puppet/parser/functions/use_privilege_separation.rb
@@ -16,21 +16,12 @@
 #
 
 Puppet::Parser::Functions.newfunction(:use_privilege_separation, :type => :rvalue) do |args|
-  os = args[0].downcase
-  osrelease = args[1]
-  osmajor = osrelease.sub(/\..*/, '')
+  ssh_vers = args[0]
 
-  ps53 = 'yes'
-  ps59 = 'sandbox'
-  ps = ps59
+  ps = 'yes'
 
-  # redhat/centos/oracle 6.x has ssh 5.3
-  if os == 'redhat' || os == 'centos' || os == 'oraclelinux'
-    ps = ps53
-
-  # debian 7.x and newer has ssh 5.9+
-  elsif os == 'debian' && osmajor.to_i <= 6
-    ps = ps53
+  if Puppet::Util::Package.versioncmp(ssh_vers, '6.6') >= 0
+    ps = 'sandbox'
   end
 
   ps

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -46,9 +46,9 @@ class ssh_hardening::client (
     $addressfamily = 'inet'
   }
 
-  $ciphers = get_ssh_ciphers($::operatingsystem, $::operatingsystemrelease, $cbc_required)
-  $macs = get_ssh_macs($::operatingsystem, $::operatingsystemrelease, $weak_hmac)
-  $kex = get_ssh_kex($::operatingsystem, $::operatingsystemrelease, $weak_kex)
+  $ciphers = get_ssh_ciphers($ssh_server_version_major, $cbc_required)
+  $macs = get_ssh_macs($ssh_server_version_major, $weak_hmac)
+  $kex = get_ssh_kex($ssh_server_version_major, $weak_kex)
 
   $ssh_options = {
     # Set the addressfamily according to IPv4 / IPv6 settings

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,11 +66,7 @@ class ssh_hardening(
   $weak_kex              = false,
   $ports                 = [ 22 ],
   $listen_to             = [],
-  $host_key_files        = [
-    '/etc/ssh/ssh_host_rsa_key',
-    '/etc/ssh/ssh_host_dsa_key',
-    '/etc/ssh/ssh_host_ecdsa_key'
-    ],
+  $host_key_files        = [],
   $client_alive_interval = 600,
   $client_alive_count    = 3,
   $allow_root_with_key   = false,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -69,6 +69,18 @@ class ssh_hardening::server (
   $options                = {},
 ) {
 
+  $ssh65 = versioncmp($ssh_server_version_major, '6.5') >= 0
+  $default_keys = $ssh65 ? {
+    true  => [ '/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ed25519_key' ],
+    false => [ '/etc/ssh/ssh_host_rsa_key' ],
+  }
+
+  $empty = size($host_key_files) == 0
+  $host_keys = $empty ? {
+    true  => $default_keys,
+    false => $host_key_files,
+  }
+
   $addressfamily = $ipv6_enabled ? {
     true  => 'any',
     false => 'inet',
@@ -119,7 +131,7 @@ class ssh_hardening::server (
       'ListenAddress'                   => $listen_to,
 
       # Define the HostKey
-      'HostKey'                         => $host_key_files,
+      'HostKey'                         => $host_keys,
 
       # Security configuration
       # ======================

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -74,10 +74,10 @@ class ssh_hardening::server (
     false => 'inet',
   }
 
-  $ciphers = get_ssh_ciphers($::operatingsystem, $::operatingsystemrelease, $cbc_required)
-  $macs = get_ssh_macs($::operatingsystem, $::operatingsystemrelease, $weak_hmac)
-  $kex = get_ssh_kex($::operatingsystem, $::operatingsystemrelease, $weak_kex)
-  $priv_sep = use_privilege_separation($::operatingsystem, $::operatingsystemrelease)
+  $ciphers = get_ssh_ciphers($ssh_server_version_major, $cbc_required)
+  $macs = get_ssh_macs($ssh_server_version_major, $weak_hmac)
+  $kex = get_ssh_kex($ssh_server_version_major, $weak_kex)
+  $priv_sep = use_privilege_separation($ssh_server_version_major)
 
   $permit_root_login = $allow_root_with_key ? {
     true  => 'without-password',

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "saz/ssh",
-      "version_requirement": ">= 2.3.6"
+      "version_requirement": ">= 2.5.0"
     },{
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.2.0"


### PR DESCRIPTION
Currently the parser functions are working on os details which have to be updated everything there is a new os version or ssh is updated in a os.
by requiring saz/ssh v2.5 we now can simply query the ssh version itself and make it more reliable.